### PR TITLE
Better bloat

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -339,24 +339,27 @@ class Heroku::Command::Pg < Heroku::Command::Base
           JOIN pg_index i ON indrelid = cc.oid
           JOIN pg_class c2 ON c2.oid = i.indexrelid
         )
-        SELECT bloat_summary.*
+        SELECT
+          type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste
         FROM
         (SELECT
-          tablename as table_name,
           'table' as type,
+          schemaname,
+          tablename as object_name,
           ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1) AS bloat,
-          CASE WHEN relpages < otta THEN '0' ELSE pg_size_pretty((bs*(table_bloat.relpages-otta)::bigint)::bigint) END AS waste
+          CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
         FROM
           table_bloat
             UNION
         SELECT
-          tablename || '::' || iname as index_name,
           'index' as type,
+          schemaname,
+          tablename || '::' || iname as object_name,
           ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1) AS bloat,
-          CASE WHEN ipages < iotta THEN '0' ELSE pg_size_pretty((bs*(ipages-iotta))::bigint) END AS waste
+          CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
         FROM
           index_bloat) bloat_summary
-        ORDER BY waste DESC
+        ORDER BY raw_waste DESC, bloat DESC
     )
     puts exec_sql(sql)
   end


### PR DESCRIPTION
Rewrite the bloat query to only support the Postgres versions actually used by Heroku, restructure it for readability with CTEs, and fold in index bloat and table bloat into a more readable structure.
