### PR TITLE
Change pg:seq_scans to become pg:scans

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,26 +112,26 @@ A heroku plugin for awesome pg:* commands that are also great and fun and super.
  public.messages     | user_resource_id_idx                       | 12 MB      |           0
 (3 rows)
 
-~ ➤ heroku pg:seq_scans
+~ ➤ heroku pg:scans
 
-               name                |  count
------------------------------------+----------
- learning_coaches                  | 44820063
- states                            | 36794975
- grade_levels                      | 13972293
- charities_customers               |  8615277
- charities                         |  4316276
- messages                          |  3922247
- contests_customers                |  2915972
- classroom_goals                   |  2142014
- contests                          |  1370267
- goals                             |  1112659
- districts                         |   158995
- rollup_reports                    |   115942
- customers                         |    93847
- schools                           |    92984
- classrooms                        |    92982
- customer_settings                 |    91226
+               name                | seq_scan | idx_scan
+-----------------------------------+----------+-----------
+ learning_coaches                  | 44820063 | 11489348
+ states                            | 36794975 | 43204043
+ grade_levels                      | 13972293 |        0
+ charities_customers               |  8615277 |   594358
+ charities                         |  4316276 | 39769769
+ messages                          |  3922247 |   432952
+ contests_customers                |  2915972 |       59
+ classroom_goals                   |  2142014 |    43480
+ contests                          |  1370267 |        7
+ goals                             |  1112659 |        0
+ districts                         |   158995 |   430853
+ rollup_reports                    |   115942 | 14465794
+ customers                         |    93847 |        4
+ schools                           |    92984 |        0
+ classrooms                        |    92982 | 85459845
+ customer_settings                 |    91226 |   859328
 (truncated results for brevity)
 
 ~ ➤ heroku pg:long_running_queries

--- a/init.rb
+++ b/init.rb
@@ -248,14 +248,15 @@ class Heroku::Command::Pg < Heroku::Command::Base
     puts exec_sql(sql)
   end
 
-  # pg:seq_scans [DATABASE]
+  # pg:scans [DATABASE]
   #
-  # show the count of seq_scans by table descending by order
+  # show the count of scans (sequential and index) per table, descending by order
   #
-  def seq_scans
+  def scans
     sql = %q(
       SELECT relname AS name,
-             seq_scan as count
+             seq_scan,
+             coalesce(idx_scan, 0) AS idx_scan
       FROM
         pg_stat_user_tables
       ORDER BY seq_scan DESC;


### PR DESCRIPTION
The absolute number of sequential scans isn't terribly meaningful on its own.

It's probably just as good an indicator of how long its been since there was a hard crash.

I'm not completely convinced that we should merge this pull request. Maybe it would be better to remove pg:seq_scans entirely, and unconfuse index_usage (thus closing #27). 

Thoughts?
