### PR TITLE
Hack around Gem::Version for 1.8.7 support

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -434,7 +434,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   def nine_two?
     return @nine_two if defined? @nine_two
-    @nine_two = Gem::Version.new(version) >= Gem::Version.new("9.2.0")
+    @nine_two = version.to_f >= 9.2
   end
 
   def pid_column


### PR DESCRIPTION
Hack to work around `uninitialized constant Heroku::Command::Pg::Gem (NameError)` error from 1.8.7, to fix #32. 
