### PR TITLE
Add anonymous tracking

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -500,16 +500,16 @@ your reply. Default is "no".
   end
 
   def track_extra(command)
-    t = Thread.new do
-      params = {'command' => command}
+    Thread.new do
       uri = URI.parse("https://pg-extras-stats.herokuapp.com/command")
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true
 
+      params = {'command' => command}
       request = Net::HTTP::Post.new(uri.request_uri, params)
-      request.set_form_data({"command" => command})
+      request.set_form_data(params)
 
-      response = http.request(request)
+      http.request(request)
     end
   end
 end


### PR DESCRIPTION
This pull request adds anonymous tracking to the pg-extras plugin in order to improve pg-extras and the pg tools in the Heroku CLI. We'd like to collect data on usage of each function to help guide us both on improvement and knowing which features to graduate into the main CLI.  

Extended to do two things; prompt for opt in/out of
collection, and sending the POST. After installing/upgrading the plugin, the
user is prompted to opt in/out of the collection with a simple y|n option
(default y). Both options set a config file in the existing ~/.heroku/ folder,
with a setting `opt-in:true|false` value.

For every command ran in the plugin, a background thread will check the this
config file and the value in it. If yes, the command is posted to the Sinatra
app. A thread is used to help ensure this process doesn't interfere with normal
usage. The plugin does not wait for or ensure the POST completes.

The data collected is anonymous (only the method name is recorded), and will be public on https://dataclips.heroku.com
