### PR TITLE
Filter current pid when listing locks

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -100,7 +100,8 @@ class Heroku::Command::Pg < Heroku::Command::Base
        ON (pg_locks.relation = pg_class.oid)
      WHERE pg_stat_activity.#{query_column} <> '<insufficient privilege>'
        AND pg_locks.pid = pg_stat_activity.#{pid_column}
-       AND pg_locks.mode = 'ExclusiveLock' order by query_start;
+       AND pg_locks.mode = 'ExclusiveLock' 
+       and pg_stat_activity.#{pid_column} <> pg_backend_pid() order by query_start;
     )
 
     track_extra('locks') if can_track?


### PR DESCRIPTION
Don't show our own query in list of locks.

Old:

```
$ heroku pg:locks -a an_app_name
 pid  | relname | transactionid | granted |   query_snippet   |   age
------+---------+---------------+---------+-------------------+----------
 5327 |         |               | t       |                  +| 00:00:00
      |         |               |         |      SELECT      +|
      |         |               |         |        pg_stat_ac |
```

new:

```
$ heroku pg:locks -a an_app_name
 pid | relname | transactionid | granted | query_snippet | age
-----+---------+---------------+---------+---------------+-----
(0 rows)
```
