### PR TITLE
Add --to and --from to pgbackups:transfer

### DIFF
--- a/lib/heroku/command/pgbackups.rb
+++ b/lib/heroku/command/pgbackups.rb
@@ -6,51 +6,56 @@ require "heroku/helpers/heroku_postgresql"
 class Heroku::Command::Pgbackups
   # pgbackups:transfer [DATABASE_FROM] DATABASE_TO
   #
+  # -t, --to TO # a to value
+  # -f, --from FROM # a from value
+  #
   # transfer directly from the first database to the second
   #
   # if no DATABASE_FROM is specified, defaults to DATABASE_URL
   # the database backup is transferred directly to DATABASE_TO without an intermediate dump
   #
   def transfer
-    db1 = shift_argument
-    db2 = shift_argument
+    destination_db = options[:to].nil? ? shift_argument : options[:to]
+    source_db      = options[:from].nil? ? shift_argument : options[:from]
 
-    if db1.nil?
-      error("pgbackups:transfer requires at least one argument")
+    if source_db.nil?
+      source_db = "DATABASE_URL"
     end
 
-    if db2.nil?
-      db2 = db1
-      db1 = "DATABASE_URL"
+    if destination_db.nil?
+      error("pgbackups:transfer requires at least a destination database")
     end
 
-    from_url, from_name = resolve_transfer(db1, 'TRANSFER_FROM')
-    to_url, to_name = resolve_transfer(db2, 'TRANSFER_TO')
+    from_url, from_name = resolve_transfer(source_db)
+    to_url, to_name = resolve_transfer(destination_db)
 
     validate_arguments!
 
-    opts      = {}
+    opts = {}
 
-    backup = transfer!(from_url, from_name, to_url, to_name, opts)
-    backup = poll_transfer!(backup)
+    if confirm_command(app, "Transfering data from #{from_name} to #{to_name}")
+      backup = transfer!(from_url, from_name, to_url, to_name, opts)
+      backup = poll_transfer!(backup)
 
-    if backup["error_at"]
-      message  =   "An error occurred and your backup did not finish."
-      message += "\nThe database is not yet online. Please try again." if backup['log'] =~ /Name or service not known/
-      message += "\nThe database credentials are incorrect."           if backup['log'] =~ /psql: FATAL:/
-      error(message)
+      if backup["error_at"]
+        message  =   "An error occurred and your backup did not finish."
+        message += "\nThe database is not yet online. Please try again." if backup['log'] =~ /Name or service not known/
+        message += "\nThe database credentials are incorrect."           if backup['log'] =~ /psql: FATAL:/
+        error(message)
+      end
     end
   end
 
   private
 
   # resolve the given database identifier
-  def resolve_transfer(db, default_name=nil)
+  def resolve_transfer(db)
     if /^postgres:/ =~ db
-      [url, default_name]
+      uri = URI.parse(db)
+      [url, "Database on #{uri.host}:#{uri.port || 5432}#{uri.path}"]
     else
       attachment = generate_resolver.resolve(db)
-      [attachment.url, db]
+      [attachment.url, db.upcase]
     end
   end
 


### PR DESCRIPTION
Adds new `-t, --to` and `-f, --from` flags to `pgbackups:transfer` to explicitly specify source and destination databases.

Wraps the work in a confirm block, because it's destructive. 

Example usage:

``` console
$ heroku pgbackups:transfer                                      
 !    pgbackups:transfer requires at least a destination database

$ heroku pgbackups:transfer -t gray          

 !    Transfering data from DATABASE_URL to GRAY
 !    To proceed, type "<app_name>" or re-run this command with --confirm <app_name>

> <app_name>

Pg_dump... 13.2kB -

$ heroku pgbackups:transfer -t gray -f silver

 !    Transfering data from SILVER to GRAY
 !    To proceed, type "<app_name>" or re-run this command with --confirm <app_name>

> <app_name>

Pg_dump... 13.2kB \

$ heroku pgbackups:transfer -t gray postgres://wna***:***-***@ec2-54-***-238-***.compute-1.amazonaws.com:5432/d***
"https://s3.amazonaws.com/***/***@***.com/***.dump?AWSAccessKeyId=*******&Expires=*****&Signature=****"

 !    Transfering data from Database on ec2-54-***-238-***.compute-1.amazonaws.com:5432/d*** to GRAY
 !    To proceed, type "<app_name>" or re-run this command with --confirm <app_name>

> ^C !    Command cancelled.
```

There's something I can't figure out though. When I use a full `postgres://` url , something somewhere echoes out the `pgbackups:url` value ? No idea where this comes from ¯_(ツ)_/¯ 
