### PR TITLE
Wrap pgbackups:transfer in confirm

### DIFF
--- a/lib/heroku/command/pgbackups.rb
+++ b/lib/heroku/command/pgbackups.rb
@@ -31,7 +31,7 @@ class Heroku::Command::Pgbackups
 
     opts      = {}
 
-    if confirm_command(app, "Transfering data from #{from_name} to #{to_name}")
+    if confirm_command(app, "WARNING: Destructive Action\nTransfering data from #{from_name} to #{to_name}")
       backup = transfer!(from_url, from_name, to_url, to_name, opts)
       backup = poll_transfer!(backup)
 


### PR DESCRIPTION
Wrap the actual transfer in pgbackups:transfer in a confirm block, because it's
destructive.

alternative to #60
