### PR TITLE
Typo in resolve transfer method

### DIFF
--- a/lib/heroku/command/pgbackups.rb
+++ b/lib/heroku/command/pgbackups.rb
@@ -47,7 +47,7 @@ class Heroku::Command::Pgbackups
   # resolve the given database identifier
   def resolve_transfer(db, default_name=nil)
     if /^postgres:/ =~ db
-      [url, default_name]
+      [db, default_name]
     else
       attachment = generate_resolver.resolve(db)
       [attachment.url, db]


### PR DESCRIPTION
Before this change, when running `pgbackups:transfer` from a database in one application to a database in another application I see:

```
$ heroku pgbackups:transfer DATABASE_URL postgres://u:p@server.amazonaws.com:db -a app
"https://s3.amazonaws.com/hkpgbackups/app@heroku.com/b123.dump?AWSAccessKeyId=k&Expires=1390504988&Signature=s"

 !    invalid format
```

With the fix it works fine, because the `to_url` in the `transfer` method gets set to the passed argument `url`.
