### PR TITLE
Update docs to use underscores

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -181,7 +181,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     end
   end
 
-  # pg:cache-hit [DATABASE]
+  # pg:cache_hit [DATABASE]
   #
   # calculates your cache hit rate (effective databases are at 99% and up)
   #
@@ -209,7 +209,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     cache_hit
   end
 
-  # pg:index-usage [DATABASE]
+  # pg:index_usage [DATABASE]
   #
   # calculates your index hit rate (effective databases are at 99% and up)
   #
@@ -322,7 +322,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     puts exec_sql(sql)
   end
 
-  # pg:total-index-size [DATABASE]
+  # pg:total_index_size [DATABASE]
   #
   # show the total size of all indexes in MB
   #
@@ -342,7 +342,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:total-index-size", "pg:total_index_size"
 
-  # pg:index-size [DATABASE]
+  # pg:index_size [DATABASE]
   #
   # show the size of indexes, descending by size
   #
@@ -365,7 +365,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:index-size", "pg:index_size"
 
-  # pg:table-size [DATABASE]
+  # pg:table_size [DATABASE]
   #
   # show the size of the tables (excluding indexes), descending by size
   #
@@ -387,7 +387,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:table-size", "pg:table_size"
 
-  # pg:table-indexes-size [DATABASE]
+  # pg:table_indexes_size [DATABASE]
   #
   # show the total size of all the indexes on each table, descending by size
   #
@@ -409,7 +409,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:table-indexes-size", "pg:table_indexes_size"
 
-  # pg:total-table-size [DATABASE]
+  # pg:total_table_size [DATABASE]
   #
   # show the size of the tables (including indexes), descending by size
   #
@@ -431,7 +431,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:total-table-size", "pg:total_table_size"
 
-  # pg:unused-indexes [DATABASE]
+  # pg:unused_indexes [DATABASE]
   #
   # show unused and almost unused indexes, ordered by their size relative to
   # the number of index scans. Exclude indexes of very small tables (less than
@@ -458,7 +458,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:unused-indexes", "pg:unused_indexes"
 
-  # pg:seq-scans [DATABASE]
+  # pg:seq_scans [DATABASE]
   #
   # show the count of sequential scans by table descending by order
   #
@@ -477,7 +477,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
 
   alias_command "pg:seq-scans", "pg:seq_scans"
 
-  # pg:long-running-queries [DATABASE]
+  # pg:long_running_queries [DATABASE]
   #
   # show all queries longer than five minutes by descending duration
   #
@@ -580,7 +580,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
     puts exec_sql(sql)
   end
 
-  # pg:vacuum-stats [DATABASE]
+  # pg:vacuum_stats [DATABASE]
   #
   # show dead rows and whether an automatic vacuum is expected to be triggered
   #


### PR DESCRIPTION
All the commands should be underscores , update docs (and thus `heroku help pg` output) to reflect 
