### PR TITLE
Move server-side pg:killall to toolbelt

### DIFF
--- a/lib/heroku/client/heroku_postgresql.rb
+++ b/lib/heroku/client/heroku_postgresql.rb
@@ -3,10 +3,6 @@ class Heroku::Client::HerokuPostgresql
     http_get "#{resource_name}/incidents"
   end
 
-  def connection_reset
-    http_post "#{resource_name}/connection_reset"
-  end
-
   def backups
     http_get "#{resource_name}/transfers"
   end

--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -640,27 +640,6 @@ class Heroku::Command::Pg < Heroku::Command::Base
     puts exec_sql(sql)
   end
 
-  alias_method :orig_killall, :killall
-  # pg:killall [DATABASE]
-  #
-  # terminates ALL connections
-  #
-  def killall
-    db = args.first
-    attachment = generate_resolver.resolve(db, "DATABASE_URL")
-
-    begin
-      client = hpg_client(attachment)
-      client.connection_reset
-      display "Connections terminated"
-
-      track_extra('killall') if can_track?
-    rescue StandardError
-      # fall back to original mechanism if something goes sideways
-      orig_killall
-    end
-  end
-
   # pg:incidents [DATABASE]
   #
   # show recents incidents.


### PR DESCRIPTION
This features is being [integrated into the main toolbelt](https://github.com/heroku/heroku/pull/1207).
