### PR TITLE
Prevent '###,###,###' on pg:outliers ncalls output

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -580,7 +580,7 @@ class Heroku::Command::Pg < Heroku::Command::Base
         SELECT #{qstr} AS qry,
         interval '1 millisecond' * total_time AS exec_time,
         to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-        to_char(calls, 'FM999G999G990') AS ncalls,
+        to_char(calls, 'FM999G999G999G990') AS ncalls,
         interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
         FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
         ORDER BY total_time DESC LIMIT 10


### PR DESCRIPTION
Turns out ncalls can exceed one billion, meaning `###,###,###` in the output. Let's up that to one trillion.
