### PR TITLE
Queries are sometimes huge, this is more readable

### DIFF
--- a/lib/heroku/command/pg.rb
+++ b/lib/heroku/command/pg.rb
@@ -739,11 +739,11 @@ SQL
     end
 
     sql = %Q(
-        SELECT #{truncated_query_string} AS qry,
-        interval '1 millisecond' * total_time AS total_exec_time,
+        SELECT interval '1 millisecond' * total_time AS total_exec_time,
         to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
         to_char(calls, 'FM999G999G999G990') AS ncalls,
-        interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+        interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+        #{truncated_query_string} AS query
         FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
         ORDER BY total_time DESC LIMIT 10
     )


### PR DESCRIPTION
Since the query is at the end, ti's much easier to visually see the table where queries are very very long.

This would be a breaking change if any tool depended on order.