### PR TITLE
Use substring instead of regexp_replace

### DIFF
--- a/commands/vacuum_stats.js
+++ b/commands/vacuum_stats.js
@@ -18,12 +18,12 @@ WITH table_opts AS (
     oid, relname, nspname,
     CASE
       WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
-        THEN regexp_replace(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*', E'\\\\\\1')::integer
+        THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
         ELSE current_setting('autovacuum_vacuum_threshold')::integer
       END AS autovacuum_vacuum_threshold,
     CASE
       WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
-        THEN regexp_replace(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*', E'\\\\\\1')::real
+        THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
         ELSE current_setting('autovacuum_vacuum_scale_factor')::real
       END AS autovacuum_vacuum_scale_factor
   FROM


### PR DESCRIPTION
Previously this query worked with Ruby plugin, but stopped working with Node one -- this is due to how Ruby's `%q()` is escaping `\\\\\\1`. Instead of modifying escape characters to fit with Node (need to change from `E'\\\\\\1'` to `E'\\\\1'` likely, as we need it to be `E'\\1'` in the real SQL), will simply use `substring` there.

The expected value of `relopts` is something like `'autovacuum_vacuum_scale_factor=0.0autovacuum_vacuum_threshold=10000'`.