### PR TITLE
1.0.8 use new heroku-pg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-pg-extras",
   "description": "A Heroku CLI plugin for awesome pg:* commands that are also great and fun and super.",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg-extras/issues"
@@ -12,7 +12,7 @@
     "execa": "0.4.0",
     "heroku-cli-addons": "1.1.3",
     "heroku-cli-util": "6.0.15",
-    "heroku-pg": "1.0.8",
+    "heroku-pg": "2.0.4",
     "lodash": "4.15.0",
     "pg": "6.1.0"
   },


### PR DESCRIPTION
The new version of heroku-pg fixes: https://github.com/heroku/heroku-pg-extras/issues/137. 