### PR TITLE
add a command that returns the number of connections per credential

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -253,6 +253,13 @@ $ heroku pg:vacuum-stats
 $ heroku pg:mandelbrot
 ```
 
+```
+$ heroku pg:user-connections
+Credential      Connections
+──────────────  ───────────
+ua7almfsv0d8tq  24
+```
+
 ## THIS IS BETA SOFTWARE
 
 Thanks for trying it out. If you find any issues, please notify us at

--- a/Readme.md
+++ b/Readme.md
@@ -249,8 +249,6 @@ $ heroku pg:vacuum-stats
  public | other_table           |             | 2013-04-26 11:41 |             41 |             47 |             58       |
  public | queue_table           |             | 2013-04-26 17:39 |             12 |          8,228 |             52       | yes
  public | picnic_table          |             |                  |             13 |              0 |             53       |
-
-$ heroku pg:mandelbrot
 ```
 
 ```
@@ -258,6 +256,10 @@ $ heroku pg:user-connections
 Credential      Connections
 ──────────────  ───────────
 ua7almfsv0d8tq  24
+```
+
+```
+$ heroku pg:mandelbrot
 ```
 
 ## THIS IS BETA SOFTWARE

--- a/commands/user_connections.js
+++ b/commands/user_connections.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const co = require('co')
+const cli = require('heroku-cli-util')
+const pg = require('heroku-pg')
+const _ = require('lodash')
+
+function * run (context, heroku) {
+  const app = context.app
+  const {database} = context.args
+
+  let db = yield pg.fetcher(heroku).addon(app, database)
+  let host = pg.host(db)
+  let rsp = yield heroku.get(`/client/v11/databases/${db.name}/user_connections`, {host})
+  let connections = _.map(rsp.connections, function (v, k) {
+    return {credential: k, count: v}
+  })
+  cli.table(connections, {columns: [ {key: 'credential', label: 'Credential'}, {key: 'count', label: 'Connections'} ]})
+}
+
+const cmd = {
+  topic: 'pg',
+  description: 'returns the number of connections per credential',
+  needsApp: true,
+  needsAuth: true,
+  args: [{name: 'database', optional: true}],
+  run: cli.command({preauth: true}, co.wrap(run))
+}
+
+module.exports = [
+  Object.assign({command: 'user-connections'}, cmd),
+  Object.assign({command: 'user_connections', hidden: true}, cmd)
+]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-pg-extras",
   "description": "A Heroku CLI plugin for awesome pg:* commands that are also great and fun and super.",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg-extras/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-pg-extras",
   "description": "A Heroku CLI plugin for awesome pg:* commands that are also great and fun and super.",
-  "version": "1.0.12",
+  "version": "1.0.11",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg-extras/issues"


### PR DESCRIPTION
```
 % heroku pg:user_connections --app APP postgresql-database-name
Credential      Connections
──────────────  ───────────
ua7almfsv0d8tq  24
```

The DUX team suggested that we create the new command in pg-extras first before we consider adding it to pg proper.