### PR TITLE
Make pg:outliers query limit configurable

### DIFF
--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -46,7 +46,7 @@ const cmd = {
   flags: [
     {name: 'reset', description: 'resets statistics gathered by pg_stat_statements'},
     {name: 'truncate', char: 't', description: 'truncate queries to 40 characters'},
-    {name: 'num', char: 'n', description: 'the number of queries to display (default: 10)'}
+    {name: 'num', char: 'n', description: 'the number of queries to display (default: 10)', hasValue: true}
   ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -19,7 +19,7 @@ function * run (context, heroku) {
     ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
     : 'query'
 
-  let limitMatch = /^(\d+)$/.exec(context.flags.limit)
+  let limitMatch = /^(\d+)$/.exec(context.flags.num)
   let limit = limitMatch ? parseInt(limitMatch[1]) : 10
 
   let query = `

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -19,8 +19,8 @@ function * run (context, heroku) {
     ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
     : 'query'
 
-  let limitString = /^(\d+)$/.exec(context.flags.limit)
-  let limit = limitString ? parseInt(limitString) : 10
+  let limitMatch = /^(\d+)$/.exec(context.flags.limit)
+  let limit = limitMatch ? parseInt(limitMatch[0]) : 10
 
   let query = `
 SELECT interval '1 millisecond' * total_time AS total_exec_time,

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -20,7 +20,7 @@ function * run (context, heroku) {
     : 'query'
 
   let limitMatch = /^(\d+)$/.exec(context.flags.limit)
-  let limit = limitMatch ? parseInt(limitMatch[0]) : 10
+  let limit = limitMatch ? parseInt(limitMatch[1]) : 10
 
   let query = `
 SELECT interval '1 millisecond' * total_time AS total_exec_time,

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -19,6 +19,9 @@ function * run (context, heroku) {
     ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
     : 'query'
 
+  let limitString = /^(\d+)$/.exec(context.flags.limit)
+  let limit = limitString ? parseInt(limitString) : 10
+
   let query = `
 SELECT interval '1 millisecond' * total_time AS total_exec_time,
 to_char((total_time/sum(total_time) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
@@ -26,7 +29,8 @@ to_char(calls, 'FM999G999G999G990') AS ncalls,
 interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
 ${truncatedQueryString} AS query
 FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-ORDER BY total_time DESC LIMIT 10
+ORDER BY total_time DESC
+LIMIT ${limit}
 `
 
   let output = yield pg.psql.exec(db, query)
@@ -41,7 +45,8 @@ const cmd = {
   args: [{name: 'database', optional: true}],
   flags: [
     {name: 'reset', description: 'resets statistics gathered by pg_stat_statements'},
-    {name: 'truncate', char: 't', description: 'truncate queries to 40 characters'}
+    {name: 'truncate', char: 't', description: 'truncate queries to 40 characters'},
+    {name: 'num', char: 'n', description: 'the number of queries to display (default: 10)'}
   ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -19,8 +19,14 @@ function * run (context, heroku) {
     ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
     : 'query'
 
-  let limitMatch = /^(\d+)$/.exec(context.flags.num)
-  let limit = limitMatch ? parseInt(limitMatch[1]) : 10
+  let limit = 10
+  if (context.flags.num) {
+    if (/^(\d+)$/.exec(context.flags.num)) {
+      limit = parseInt(context.flags.num)
+    } else {
+      throw new Error(`Cannot parse num param value "${context.flags.num}" to a number`)
+    }
+  }
 
   let query = `
 SELECT interval '1 millisecond' * total_time AS total_exec_time,


### PR DESCRIPTION
This PR makes it possible for a user to query for more (or less) outlier queries than the default 10. This is particularly useful once the top queries are fairly consistent and known.