### PR TITLE
Prevent unsupported commands from running

### DIFF
--- a/commands/fdwsql.js
+++ b/commands/fdwsql.js
@@ -36,7 +36,8 @@ function * run (context, heroku) {
   const {prefix, database} = context.args
 
   let db = yield pg.fetcher(heroku).database(app, database)
-  yield util.ensureNonStarterPlan(db)
+  let addon = yield pg.fetcher(heroku).addon(app, database)
+  yield util.ensureNonStarterPlan(addon)
   cli.log('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
   cli.log(`DROP SERVER IF EXISTS ${prefix}_db;`)
   cli.log(`CREATE SERVER ${prefix}_db

--- a/commands/fdwsql.js
+++ b/commands/fdwsql.js
@@ -3,6 +3,7 @@
 const co = require('co')
 const cli = require('heroku-cli-util')
 const pg = require('heroku-pg')
+const util = require('../lib/util')
 
 const query = prefix => `
 SELECT
@@ -35,6 +36,7 @@ function * run (context, heroku) {
   const {prefix, database} = context.args
 
   let db = yield pg.fetcher(heroku).database(app, database)
+  yield util.ensureNonStarterPlan(db)
   cli.log('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
   cli.log(`DROP SERVER IF EXISTS ${prefix}_db;`)
   cli.log(`CREATE SERVER ${prefix}_db

--- a/commands/stats_reset.js
+++ b/commands/stats_reset.js
@@ -3,12 +3,14 @@
 const co = require('co')
 const cli = require('heroku-cli-util')
 const pg = require('heroku-pg')
+const util = require('../lib/util')
 
 function * run (context, heroku) {
   const app = context.app
   const {database} = context.args
 
   let db = yield pg.fetcher(heroku).addon(app, database)
+  yield util.ensureNonStarterPlan(db)
   let host = pg.host(db)
   let rsp = yield heroku.put(`/client/v11/databases/${db.name}/stats_reset`, {host})
   cli.log(rsp.message)

--- a/commands/user_connections.js
+++ b/commands/user_connections.js
@@ -4,12 +4,14 @@ const co = require('co')
 const cli = require('heroku-cli-util')
 const pg = require('heroku-pg')
 const _ = require('lodash')
+const util = require('../lib/util')
 
 function * run (context, heroku) {
   const app = context.app
   const {database} = context.args
 
   let db = yield pg.fetcher(heroku).addon(app, database)
+  yield util.ensureNonStarterPlan(db)
   let host = pg.host(db)
 
   let credentials = yield heroku.get(`/postgres/v0/databases/${db.name}/credentials`, { host: host })

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,7 +21,7 @@ You can install it by running:
 
 function * ensureNonStarterPlan (db) {
   if (!!db.plan.name.match(/(dev|basic)$/)) {
-    throw new Error(`This command is not supported on hobby tier databases`)
+    throw new Error(`This operation is not supported by Hobby tier databases.`)
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,5 +27,5 @@ function * ensureNonStarterPlan (db) {
 
 module.exports = {
   ensurePGStatStatement: co.wrap(ensurePGStatStatement),
-  ensureNonStarterPlan: co.warp(ensureNonStarterPlan)
+  ensureNonStarterPlan: co.wrap(ensureNonStarterPlan)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,12 +13,19 @@ SELECT exists(
 
   if (!output.includes('t')) {
     throw new Error(`pg_stat_statements extension need to be installed in the public schema first.
-This extension is only available on Postgres versions 9.2 or greater. You can install it by running:
+You can install it by running:
 
     CREATE EXTENSION pg_stat_statements;`)
   }
 }
 
+function * ensureNonStarterPlan (db) {
+  if (!!db.plan.name.match(/(dev|basic)$/)) {
+    throw new Error(`This command is not supported on hobby tier databases`)
+  }
+}
+
 module.exports = {
-  ensurePGStatStatement: co.wrap(ensurePGStatStatement)
+  ensurePGStatStatement: co.wrap(ensurePGStatStatement),
+  ensureNonStarterPlan: co.warp(ensureNonStarterPlan)
 }


### PR DESCRIPTION
Some change will be made on the server side, but it's always nice to have such thing in client side. I think. Also hobby tier doesn't support fdw.
https://github.com/heroku/yobuko/pull/618

I noticed that this plugin also uses lots of old plugins which we may want to revisit:
https://github.com/heroku/heroku-pg-extras/blob/master/package.json