### PR TITLE
Update blocking query

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,9 +90,9 @@ $ heroku pg:calls
 
 ```
 $ heroku pg:blocking
- blocked_pid |    blocking_statement    | blocking_duration | blocking_pid |                                        blocked_statement                           | blocked_duration
--------------+--------------------------+-------------------+--------------+------------------------------------------------------------------------------------+------------------
-         461 | select count(*) from app | 00:00:03.838314   |        15682 | UPDATE "app" SET "updated_at" = '2013-03-04 15:07:04.746688' WHERE "id" = 12823149 | 00:00:03.821826
+ blocked_pid |  blocked_user  |       blocked_statement        | blocked_duration | blocking_pid | blocking_user  |                   blocking_statement                   | blocking_duration
+-------------+----------------+--------------------------------+------------------+--------------+----------------+--------------------------------------------------------+-------------------
+        6677 | uasnupk1hb98g1 | select * from garbage limit 1; | 00:00:17.494953  |         6676 | uasnupk1hb98g1 | alter table garbage rename column content to content2; | 00:00:24.010141
 (1 row)
 ```
 

--- a/commands/blocking.js
+++ b/commands/blocking.js
@@ -5,20 +5,32 @@ const cli = require('heroku-cli-util')
 const pg = require('heroku-pg')
 
 const query = `
-SELECT bl.pid AS blocked_pid,
-  ka.query AS blocking_statement,
-  now() - ka.query_start AS blocking_duration,
-  kl.pid AS blocking_pid,
-  a.query AS blocked_statement,
-  now() - a.query_start AS blocked_duration
-FROM pg_catalog.pg_locks bl
-JOIN pg_catalog.pg_stat_activity a
-  ON bl.pid = a.pid
-JOIN pg_catalog.pg_locks kl
-  JOIN pg_catalog.pg_stat_activity ka
-    ON kl.pid = ka.pid
-ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
-WHERE NOT bl.granted
+SELECT
+    blocked_locks.pid AS blocked_pid,
+    blocked_activity.usename AS blocked_user,
+    blocked_activity.query AS blocked_statement,
+    now() - blocked_activity.query_start AS blocked_duration,
+    blocking_locks.pid AS blocking_pid,
+    blocking_activity.usename AS blocking_user,
+    blocking_activity.query AS blocking_statement,
+    now() - blocking_activity.query_start AS blocking_duration
+FROM
+    pg_catalog.pg_locks blocked_locks
+JOIN pg_catalog.pg_stat_activity blocked_activity ON blocked_activity.pid = blocked_locks.pid
+JOIN pg_catalog.pg_locks blocking_locks ON blocking_locks.locktype = blocked_locks.locktype
+    AND blocking_locks.database IS NOT DISTINCT FROM blocked_locks.database
+    AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+    AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+    AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+    AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+    AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+    AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+    AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+    AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+    AND blocking_locks.pid != blocked_locks.pid
+JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+WHERE
+    NOT blocked_locks.granted;
 `
 
 function * run (context, heroku) {


### PR DESCRIPTION
This commit updates the blocking check query with a more modern
approach. The older query was used for 9.2 and below. The new query
is lifted from: https://wiki.postgresql.org/wiki/Lock_Monitoring,
with some additions to including blocked and blocking duration,
similar to the old query.

* Update blocking query to use a more modern approach
* Update README to match new output

Fixes #150