### PR TITLE
Fix bloat query incorrectly categorising objects

### DIFF
--- a/commands/bloat.js
+++ b/commands/bloat.js
@@ -36,6 +36,7 @@ WITH constants AS (
   FROM bloat_info
   JOIN pg_class cc ON cc.relname = bloat_info.tablename
   JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
+  WHERE cc.relkind IN ('t', 'm', 'r') -- "table" like objects
 ), index_bloat AS (
   SELECT
     schemaname, tablename, bs,
@@ -46,6 +47,7 @@ WITH constants AS (
   JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname AND nn.nspname <> 'information_schema'
   JOIN pg_index i ON indrelid = cc.oid
   JOIN pg_class c2 ON c2.oid = i.indexrelid
+  WHERE c2.relkind = 'i' -- indexes
 )
 SELECT
   type, schemaname, object_name, bloat, pg_size_pretty(raw_waste) as waste


### PR DESCRIPTION
This commit updates the bloat query to correctly categorise
database objects, as previously the `table_bloat` CTE did not
sufficiently filter out indexes, so some indexes may have been
reported as tables incorrectly.

* Add `WHERE` clauses to filter based on `relkind` for
  `table_bloat` and `index_bloat` CTEs

Fixes #143