### PR TITLE
Expand pg:locks query

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,15 +43,22 @@ $ heroku pg:ps
 
 ```
 $ heroku pg:locks
- procpid | relname | transactionid | granted |     query_snippet     |       age
----------+---------+---------------+---------+-----------------------+-----------------
-   31776 |         |               | t       | <IDLE> in transaction | 00:19:29.837898
-   31776 |         |          1294 | t       | <IDLE> in transaction | 00:19:29.837898
-   31912 |         |               | t       | select * from hello;  | 00:19:17.94259
-    3443 |         |               | t       |                      +| 00:00:00
-         |         |               |         |    select            +|
-         |         |               |         |      pg_stat_activi   |
-(4 rows)
+ pid  |   vxid    |  schema  |       relname        | relkind | xid_lock | granted |   lock_type   |      lock_mode      |    query_snippet   |       age
+------+-----------+----------+----------------------+---------+----------+---------+---------------+---------------------+--------------------+-----------------
+ 2998 | 3/9561283 | public   | garbage_pkey         | i       |          | t       | relation      | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         | 2020     | t       | transactionid | ExclusiveLock       |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 | pg_toast | pg_toast_20820_index | i       |          | t       | relation      | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 | pg_toast | pg_toast_20820       | t       |          | t       | relation      | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 | public   | garbage              | r       |          | t       | relation      | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 | public   | garbage_id_seq       | S       |          | t       | relation      | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+ 2998 | 3/9561283 |          |                      |         |          | t       | object        | AccessExclusiveLock |  drop table test;  | 01:04:24.434988
+(13 rows)
 ```
 
 ```


### PR DESCRIPTION
This commit expands the pg:locks query to better handle expanded
lock types, and provide richer information about the locks.

The main downside is that by including more lock types, there is
a lot more information. For example, obtaining an `AccessExclusiveLock`
on a table (as part of `DROP TABLE`), grabs locks on sequences, TOAST
data and indexes as well as the table itself, as well as locks on
`pg_type` and other system tables, that aren't easily understood.

This is best highlighted with the updated example in the README.

In order to help account for this, new columns have been added to
help identify the lock types as well as lock modes, and provide
some further information. This might be too much, so feedback
is deeply appreciated.

* Expand locks query to include `AccessExclusiveLock` and
`RowExclusiveLock`
* Add further metadata about acquired locks to output
* Update example

Fixes #149