### PR TITLE
update to new heroku-pg version

### DIFF
--- a/commands/bloat.js
+++ b/commands/bloat.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/blocking.js
+++ b/commands/blocking.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 const query = `
 SELECT bl.pid AS blocked_pid,

--- a/commands/cache_hit.js
+++ b/commands/cache_hit.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 const query = `
 SELECT

--- a/commands/calls.js
+++ b/commands/calls.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 const util = require('../lib/util')
 
 function * run (context, heroku) {

--- a/commands/extensions.js
+++ b/commands/extensions.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/fdwsql.js
+++ b/commands/fdwsql.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 const util = require('../lib/util')
 
 const query = prefix => `

--- a/commands/index_size.js
+++ b/commands/index_size.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/index_usage.js
+++ b/commands/index_usage.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 const query = `
 SELECT relname,

--- a/commands/locks.js
+++ b/commands/locks.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/long_running_queries.js
+++ b/commands/long_running_queries.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/mandelbrot.js
+++ b/commands/mandelbrot.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 const util = require('../lib/util')
 
 function * run (context, heroku) {

--- a/commands/records_rank.js
+++ b/commands/records_rank.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/seq_scans.js
+++ b/commands/seq_scans.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/stats_reset.js
+++ b/commands/stats_reset.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 const util = require('../lib/util')
 
 function * run (context, heroku) {

--- a/commands/table_indexes_size.js
+++ b/commands/table_indexes_size.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/table_size.js
+++ b/commands/table_size.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/total_index_size.js
+++ b/commands/total_index_size.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 const query = `
 SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size

--- a/commands/total_table_size.js
+++ b/commands/total_table_size.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/unused_indexes.js
+++ b/commands/unused_indexes.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/commands/user_connections.js
+++ b/commands/user_connections.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 const _ = require('lodash')
 const util = require('../lib/util')
 

--- a/commands/vacuum_stats.js
+++ b/commands/vacuum_stats.js
@@ -2,7 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const co = require('co')
-const pg = require('heroku-pg')
+const pg = require('@heroku-cli/plugin-pg-v5')
 
 function * ensurePGStatStatement (db) {
   let query = `

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "execa": "0.4.0",
     "heroku-cli-addons": "1.1.3",
     "heroku-cli-util": "6.0.15",
-    "heroku-pg": "2.0.16",
+    "@heroku-cli/plugin-pg-v5": "7.19.4",
     "lodash": "4.17.5",
     "pg": "6.1.6"
   },


### PR DESCRIPTION
This updates this plugin to use the new `heroku-pg` version which is now shipped with the main heroku CLI.

This means this plugin now supports the new bastion related api heroku postgres exposes (and was tested to do so).