### PR TITLE
Correct pg:calls description

### DIFF
--- a/commands/calls.js
+++ b/commands/calls.js
@@ -30,7 +30,7 @@ ORDER BY calls DESC LIMIT 10
 
 const cmd = {
   topic: 'pg',
-  description: 'show 10 queries that have longest execution time in aggregate',
+  description: 'show 10 queries that have highest frequency of execution',
   needsApp: true,
   needsAuth: true,
   args: [{name: 'database', optional: true}],


### PR DESCRIPTION
A coworker (@brendar) pointed out that the `pg:calls` description is the same as the `pg:outliers` description. Hoping to straighten that out.