### PR TITLE
Show the schema name in queries where it's applicable but missing

### DIFF
--- a/commands/index_size.js
+++ b/commands/index_size.js
@@ -8,14 +8,14 @@ function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
-SELECT c.relname AS name,
+SELECT n.nspname || '.' || c.relname AS name,
   pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
 FROM pg_class c
 LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
 WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
 AND n.nspname !~ '^pg_toast'
 AND c.relkind='i'
-GROUP BY c.relname
+GROUP BY n.nspname, c.relname
 ORDER BY sum(c.relpages) DESC;
   `
 

--- a/commands/index_usage.js
+++ b/commands/index_usage.js
@@ -5,7 +5,7 @@ const cli = require('heroku-cli-util')
 const pg = require('@heroku-cli/plugin-pg-v5')
 
 const query = `
-SELECT relname,
+SELECT schemaname || '.' || relname,
    CASE idx_scan
      WHEN 0 THEN 'Insufficient data'
      ELSE (100 * idx_scan / (seq_scan + idx_scan))::text

--- a/commands/records_rank.js
+++ b/commands/records_rank.js
@@ -9,7 +9,7 @@ function * run (context, heroku) {
 
   let query = `
 SELECT
-  relname AS name,
+  schemaname || '.' || relname AS name,
   n_live_tup AS estimated_count
 FROM
   pg_stat_user_tables

--- a/commands/seq_scans.js
+++ b/commands/seq_scans.js
@@ -8,7 +8,7 @@ function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
-SELECT relname AS name,
+SELECT schemaname || '.' || relname AS name,
        seq_scan as count
 FROM
   pg_stat_user_tables

--- a/commands/table_indexes_size.js
+++ b/commands/table_indexes_size.js
@@ -8,7 +8,7 @@ function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
-SELECT c.relname AS table,
+SELECT n.nspname || '.' || c.relname AS table,
   pg_size_pretty(pg_indexes_size(c.oid)) AS index_size
 FROM pg_class c
 LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)

--- a/commands/table_size.js
+++ b/commands/table_size.js
@@ -8,7 +8,7 @@ function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
-SELECT c.relname AS name,
+SELECT n.nspname || '.' || c.relname AS name,
   pg_size_pretty(pg_table_size(c.oid)) AS size
 FROM pg_class c
 LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)

--- a/commands/total_table_size.js
+++ b/commands/total_table_size.js
@@ -8,7 +8,7 @@ function * run (context, heroku) {
   let db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
   let query = `
-SELECT c.relname AS name,
+SELECT n.nspname || '.' || c.relname AS name,
   pg_size_pretty(pg_total_relation_size(c.oid)) AS size
 FROM pg_class c
 LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)


### PR DESCRIPTION
We use schemas to separate customer data, which means that we have multiple tables with the same name. This unfortunately makes the pg extras a lot less useful because we can't tell which table it's actually talking about.

This changes that by adding the schema name to the queries. I followed the same pattern used in queries where schema is included, so the schema name shows up before the table name joined by a period: `schemaname.tablename` This also has the benefit of being easy to search in the output.

I believe this also solves #161 