### PR TITLE
Fix bug when doing an version check with \timing on

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -30,7 +30,7 @@ function * newTotalExecTimeField (db) {
   const newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery, ['-t', '-q'])
 
   // error checks
-  newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")[0].trim()
+  const newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")[0].trim()
 
   if (newTotalExecTimeField !== 't' && newTotalExecTimeField !== 'f') {
     throw new Error(`Unable to determine database version, expected "t" or "f", got: "${newTotalExecTimeField}"`)

--- a/lib/util.js
+++ b/lib/util.js
@@ -26,15 +26,11 @@ function * ensureNonStarterPlan (db) {
 }
 
 function * newTotalExecTimeField (db) {
-  const newTotalExecTimeFieldQuery = 'SELECT current_setting(\'server_version_num\')::numeric >= 130000'
-  const newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery)
+  let newTotalExecTimeFieldQuery = `SELECT current_setting('server_version_num')::numeric >= 130000`
+  let newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery, ['-t', '-q'])
 
   // error checks
-  let newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")
-  if (newTotalExecTimeField.length < 3) {
-    throw new Error(`Unable to determine database version`)
-  }
-  newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')[2].trim()
+  newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")[0].trim()
 
   if (newTotalExecTimeField !== 't' && newTotalExecTimeField !== 'f') {
     throw new Error(`Unable to determine database version, expected "t" or "f", got: "${newTotalExecTimeField}"`)

--- a/lib/util.js
+++ b/lib/util.js
@@ -30,9 +30,9 @@ function * newTotalExecTimeField (db) {
   const newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery)
 
   // error checks
-  let newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')
-  if (newTotalExecTimeField.length !== 6) {
-    throw new Error('Unable to determine database version')
+  let newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")
+  if (newTotalExecTimeField.length < 3) {
+    throw new Error(`Unable to determine database version`)
   }
   newTotalExecTimeField = newTotalExecTimeFieldRaw.split('\n')[2].trim()
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -26,8 +26,8 @@ function * ensureNonStarterPlan (db) {
 }
 
 function * newTotalExecTimeField (db) {
-  let newTotalExecTimeFieldQuery = `SELECT current_setting('server_version_num')::numeric >= 130000`
-  let newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery, ['-t', '-q'])
+  const newTotalExecTimeFieldQuery = `SELECT current_setting('server_version_num')::numeric >= 130000`
+  const newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery, ['-t', '-q'])
 
   // error checks
   newTotalExecTimeField = newTotalExecTimeFieldRaw.split("\n")[0].trim()


### PR DESCRIPTION
This PR allows the version check to execute with or without `\timing` enabled while still allowing us to guard against index out of range errors.

Fixes: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008x6klIAA/view