### PR TITLE
upgrade to latest fetcher library from pg-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "execa": "0.4.0",
     "heroku-cli-addons": "1.1.3",
     "heroku-cli-util": "8.0.12",
-    "@heroku-cli/plugin-pg-v5": "7.19.4",
+    "@heroku-cli/plugin-pg-v5": "7.56.1",
     "lodash": ">=4.17.11",
     "pg": "6.1.6"
   },


### PR DESCRIPTION
uses the updated fetcher code from https://github.com/heroku/cli/pull/1838

was tested and it did correctly use the new library with just a bump in the dependency.