### PR TITLE
Check heroku_ext schema for pg_stat_statements

### DIFF
--- a/commands/calls.js
+++ b/commands/calls.js
@@ -8,7 +8,7 @@ const util = require('../lib/util')
 function * run (context, heroku) {
   const db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
-  yield util.ensurePGStatStatement(db)
+  const namespace = yield util.extractPGStatStatementNamespace(db)
 
   const truncatedQueryString = context.flags.truncate
     ? 'CASE WHEN length(query) <= 40 THEN query ELSE substr(query, 0, 39) || \'…\' END'
@@ -28,7 +28,7 @@ interval '1 millisecond' * ${totalExecTimeField} AS exec_time,
 to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
 to_char(calls, 'FM999G999G990') AS ncalls,
 interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
-FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+FROM ${namespace}.pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY calls DESC LIMIT 10
 `
 

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -8,7 +8,7 @@ const util = require('../lib/util')
 function * run (context, heroku) {
   const db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
-  yield util.ensurePGStatStatement(db)
+  const namespace = yield util.extractPGStatStatementNamespace(db)
 
   if (context.flags.reset) {
     yield pg.psql.exec(db, 'select pg_stat_statements_reset()')
@@ -42,7 +42,7 @@ to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0
 to_char(calls, 'FM999G999G999G990') AS ncalls,
 interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
 ${truncatedQueryString} AS query
-FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
+FROM ${namespace}.pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY ${totalExecTimeField} DESC
 LIMIT ${limit}
 `

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,19 +3,21 @@
 const co = require('co')
 const pg = require('@heroku-cli/plugin-pg-v5')
 
-function * ensurePGStatStatement (db) {
+function * extractPGStatStatementNamespace (db) {
   const query = `
-SELECT exists(
-  SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
-  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
-) AS available`
-  const output = yield pg.psql.exec(db, query)
+SELECT n.nspname FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
+WHERE e.extname='pg_stat_statements' AND (n.nspname = 'public' or n.nspname = 'heroku_ext') LIMIT 1`
+  const output = yield pg.psql.exec(db, query, ['-t', '-q'])
 
-  if (!output.includes('t')) {
-    throw new Error(`pg_stat_statements extension need to be installed in the public schema first.
+  const namespace = output.trim()
+
+  if (namespace === '') {
+    throw new Error(`pg_stat_statements extension need to be installed in the heroku_ext schema first.
 You can install it by running:
 
-    CREATE EXTENSION pg_stat_statements;`)
+    CREATE EXTENSION pg_stat_statements WITH SCHEMA heroku_ext;`)
+  } else {
+    return namespace
   }
 }
 
@@ -40,7 +42,7 @@ function * newTotalExecTimeField (db) {
 }
 
 module.exports = {
-  ensurePGStatStatement: co.wrap(ensurePGStatStatement),
+  extractPGStatStatementNamespace: co.wrap(extractPGStatStatementNamespace),
   ensureNonStarterPlan: co.wrap(ensureNonStarterPlan),
   newTotalExecTimeField: co.wrap(newTotalExecTimeField)
 }


### PR DESCRIPTION
In https://devcenter.heroku.com/changelog-items/2446, the default schema for new postgres extensions is `heroku_ext`. This change checks both the `public` and `heroku_ext` schemas for the `pg_stat_statements` extension and uses the correct schema in the queries for `heroku pg:outliers` and `heroku pg:calls`.