### PR TITLE
Look for pg_stat_statements in heroku_ext too

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -7,7 +7,7 @@ function * ensurePGStatStatement (db) {
   const query = `
 SELECT exists(
   SELECT 1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace
-  WHERE e.extname='pg_stat_statements' AND n.nspname = 'public'
+  WHERE e.extname='pg_stat_statements' AND n.nspname IN ('public', 'heroku_ext')
 ) AS available`
   const output = yield pg.psql.exec(db, query)
 


### PR DESCRIPTION
Following: https://devcenter.heroku.com/changelog-items/2446.

`pg_stat_statements` can exist in any of the `public` and `heroku_ext` schemas, and this plugin needs to account for that.

This is the equivalent of https://github.com/heroku/cli/pull/2038 for `pg-extras`, given the command duplication between this plugin and the core CLI.

cc @verajohne @subakva