### PR TITLE
Fixing pg:extensions for essential plans

### DIFF
--- a/commands/extensions.js
+++ b/commands/extensions.js
@@ -3,16 +3,25 @@
 const co = require('co')
 const cli = require('heroku-cli-util')
 const pg = require('@heroku-cli/plugin-pg-v5')
+const util = require('../lib/util')
 
 function * run (context, heroku) {
   const db = yield pg.fetcher(heroku).database(context.app, context.args.database)
 
-  const query = `
-SELECT * FROM pg_available_extensions WHERE name IN (SELECT unnest(string_to_array(current_setting('extwlist.extensions'), ',')))
-`
+  if (util.essentialNumPlan(db.attachment.addon)) {
+    const query = `SELECT *
+                   FROM pg_available_extensions
+                   WHERE name IN (SELECT unnest(string_to_array(current_setting('rds.extensions'), ', ')))`
 
-  const output = yield pg.psql.exec(db, query)
-  process.stdout.write(output)
+    const output = yield pg.psql.exec(db, query)
+    process.stdout.write(output)
+  } else {
+    const query = `SELECT *
+                   FROM pg_available_extensions
+                   WHERE name IN (SELECT unnest(string_to_array(current_setting('extwlist.extensions'), ',')))`
+    const output = yield pg.psql.exec(db, query)
+    process.stdout.write(output)
+  }
 }
 
 const cmd = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -25,6 +25,10 @@ function * ensureEssentialTierPlan (db) {
   }
 }
 
+function essentialNumPlan (a) {
+  return !!a.plan.name.split(':')[1].match(/^essential/)
+}
+
 function * newTotalExecTimeField (db) {
   const newTotalExecTimeFieldQuery = `SELECT current_setting('server_version_num')::numeric >= 130000`
   const newTotalExecTimeFieldRaw = yield pg.psql.exec(db, newTotalExecTimeFieldQuery, ['-t', '-q'])
@@ -42,5 +46,6 @@ function * newTotalExecTimeField (db) {
 module.exports = {
   ensurePGStatStatement: co.wrap(ensurePGStatStatement),
   ensureEssentialTierPlan: co.wrap(ensureEssentialTierPlan),
+  essentialNumPlan: essentialNumPlan,
   newTotalExecTimeField: co.wrap(newTotalExecTimeField)
 }


### PR DESCRIPTION
Previously essential plans caused the pg:extensions command to break. They'll now run the correct query to list extensions.