### PR TITLE
making sure calls works w/essentials, changing to be same table forma…

### DIFF
--- a/commands/calls.js
+++ b/commands/calls.js
@@ -23,13 +23,14 @@ function * run (context, heroku) {
   }
 
   const query = `
-SELECT ${truncatedQueryString} AS qry,
-interval '1 millisecond' * ${totalExecTimeField} AS exec_time,
+SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
 to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
-to_char(calls, 'FM999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time
+to_char(calls, 'FM999G999G999G990') AS ncalls,
+interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+${truncatedQueryString} AS query
 FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
-ORDER BY calls DESC LIMIT 10
+ORDER BY calls DESC
+LIMIT 10
 `
 
   const output = yield pg.psql.exec(db, query)


### PR DESCRIPTION
making sure `pg:calls` works w/essentials, changing to be same table format as `pg:outliers`
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001bQge1YAC/view

before: 
![Screenshot 2023-10-16 at 2 18 00 PM](https://github.com/heroku/heroku-pg-extras/assets/22723164/c4620415-bb70-4096-83a6-e4adcccb2f19)

after:
![Screenshot 2023-10-16 at 2 18 37 PM](https://github.com/heroku/heroku-pg-extras/assets/22723164/9ef6989e-b6ee-4a9a-93dc-52c10b1ca4c8)

To test:
Pull down the branch and run:
`heroku plugins:link`
from inside the pg-extras directory and it'll install the plugin as that git repo instead of an NPM package.
