### PR TITLE
feat: update `pg:calls` and `pg:outliers` to support PG17

### DIFF
--- a/commands/calls.js
+++ b/commands/calls.js
@@ -22,10 +22,10 @@ function * run (context, heroku) {
     totalExecTimeField = 'total_time'
   }
 
-  const newBlkReadFields = yield util.newBlkTimeFields(db)
+  const newBlkTimeFields = yield util.newBlkTimeFields(db)
   let blkReadField = ''
   let blkWriteField = ''
-  if (newBlkReadFields) {
+  if (newBlkTimeFields) {
     blkReadField = 'shared_blk_read_time'
     blkWriteField = 'shared_blk_write_time'
   } else {

--- a/commands/calls.js
+++ b/commands/calls.js
@@ -22,11 +22,22 @@ function * run (context, heroku) {
     totalExecTimeField = 'total_time'
   }
 
+  const newBlkReadFields = yield util.newBlkTimeFields(db)
+  let blkReadField = ''
+  let blkWriteField = ''
+  if (newBlkReadFields) {
+    blkReadField = 'shared_blk_read_time'
+    blkWriteField = 'shared_blk_write_time'
+  } else {
+    blkReadField = 'blk_read_time'
+    blkWriteField = 'blk_write_time'
+  }
+
   const query = `
 SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
 to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
 to_char(calls, 'FM999G999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+interval '1 millisecond' * (${blkReadField} + ${blkWriteField} ) AS sync_io_time,
 ${truncatedQueryString} AS query
 FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY calls DESC

--- a/commands/calls.js
+++ b/commands/calls.js
@@ -37,7 +37,7 @@ function * run (context, heroku) {
 SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
 to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
 to_char(calls, 'FM999G999G999G990') AS ncalls,
-interval '1 millisecond' * (${blkReadField} + ${blkWriteField} ) AS sync_io_time,
+interval '1 millisecond' * (${blkReadField} + ${blkWriteField}) AS sync_io_time,
 ${truncatedQueryString} AS query
 FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY calls DESC

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -36,16 +36,16 @@ function * run (context, heroku) {
     totalExecTimeField = 'total_time'
   }
 
-    const newBlkReadFields = yield util.newBlkTimeFields(db)
-    let blkReadField = ''
-    let blkWriteField = ''
-    if (newBlkReadFields) {
-      blkReadField = 'shared_blk_read_time'
-      blkWriteField = 'shared_blk_write_time'
-    } else {
-      blkReadField = 'blk_read_time'
-      blkWriteField = 'blk_write_time'
-    }
+  const newBlkTimeFields = yield util.newBlkTimeFields(db)
+  let blkReadField = ''
+  let blkWriteField = ''
+  if (newBlkTimeFields) {
+    blkReadField = 'shared_blk_read_time'
+    blkWriteField = 'shared_blk_write_time'
+  } else {
+    blkReadField = 'blk_read_time'
+    blkWriteField = 'blk_write_time'
+  }
 
   const query = `
 SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,

--- a/commands/outliers.js
+++ b/commands/outliers.js
@@ -36,11 +36,22 @@ function * run (context, heroku) {
     totalExecTimeField = 'total_time'
   }
 
+    const newBlkReadFields = yield util.newBlkTimeFields(db)
+    let blkReadField = ''
+    let blkWriteField = ''
+    if (newBlkReadFields) {
+      blkReadField = 'shared_blk_read_time'
+      blkWriteField = 'shared_blk_write_time'
+    } else {
+      blkReadField = 'blk_read_time'
+      blkWriteField = 'blk_write_time'
+    }
+
   const query = `
 SELECT interval '1 millisecond' * ${totalExecTimeField} AS total_exec_time,
 to_char((${totalExecTimeField}/sum(${totalExecTimeField}) OVER()) * 100, 'FM90D0') || '%'  AS prop_exec_time,
 to_char(calls, 'FM999G999G999G990') AS ncalls,
-interval '1 millisecond' * (blk_read_time + blk_write_time) AS sync_io_time,
+interval '1 millisecond' * (${blkReadField} + ${blkWriteField}) AS sync_io_time,
 ${truncatedQueryString} AS query
 FROM pg_stat_statements WHERE userid = (SELECT usesysid FROM pg_user WHERE usename = current_user LIMIT 1)
 ORDER BY ${totalExecTimeField} DESC

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,7 +51,7 @@ function * newBlkTimeFields (db) {
   const newBlkTimeField = newBlkTimeFieldsRaw.split('\n')[0].trim()
 
   if (newBlkTimeField !== 't' && newBlkTimeField !== 'f') {
-    throw new Error(`Unable to determine database version, expected "t" or "f", got: "${newBlkReadField}"`)
+    throw new Error(`Unable to determine database version, expected "t" or "f", got: "${newBlkTimeField}"`)
   }
 
   return newBlkTimeField === 't'

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,5 +62,5 @@ module.exports = {
   ensureEssentialTierPlan: co.wrap(ensureEssentialTierPlan),
   essentialNumPlan: essentialNumPlan,
   newTotalExecTimeField: co.wrap(newTotalExecTimeField),
-  newBlkReadFields: co.wrap(newBlkTimeFields)
+  newBlkTimeFields: co.wrap(newBlkTimeFields)
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,9 +43,24 @@ function * newTotalExecTimeField (db) {
   return newTotalExecTimeField === 't'
 }
 
+function * newBlkTimeFields (db) {
+  const newBlkTimeFieldsQuery = `SELECT current_setting('server_version_num')::numeric >= 170000`
+  const newBlkTimeFieldsRaw = yield pg.psql.exec(db, newBlkTimeFieldsQuery, ['-t', '-q'])
+
+  // error checks
+  const newBlkTimeField = newBlkTimeFieldsRaw.split('\n')[0].trim()
+
+  if (newBlkTimeField !== 't' && newBlkTimeField !== 'f') {
+    throw new Error(`Unable to determine database version, expected "t" or "f", got: "${newBlkReadField}"`)
+  }
+
+  return newBlkTimeField === 't'
+}
+
 module.exports = {
   ensurePGStatStatement: co.wrap(ensurePGStatStatement),
   ensureEssentialTierPlan: co.wrap(ensureEssentialTierPlan),
   essentialNumPlan: essentialNumPlan,
-  newTotalExecTimeField: co.wrap(newTotalExecTimeField)
+  newTotalExecTimeField: co.wrap(newTotalExecTimeField),
+  newBlkReadFields: co.wrap(newBlkTimeFields)
 }


### PR DESCRIPTION
Adds handing for new column names in `pg_stat_statements` in Postgres v17. 

Note: the core CLI also contains a `pg:outliers` command, which takes precedence over the command in this plugin. We're discussing internally how to handle these duplicative commands; for now I've updated both of them, though I'm only able to test `pg:calls`.

Testing:
- `heroku plugins:uninstall @heroku-cli/heroku-pg-extras`
- `yarn install`
- `heroku plugins:link .`
- test on a PG17 Postgres:
```
heroku pg:calls HEROKU_POSTGRESQL_TCOLL_MAUVE_URL -a tc-data-dev
 total_exec_time | prop_exec_time | ncalls | sync_io_time |                                                              query                                                               
-----------------+----------------+--------+--------------+----------------------------------------------------------------------------------------------------------------------------------
 00:00:00.006463 | 2.1%           | 1,209  | 00:00:00     | SELECT $1
 00:00:00.008409 | 2.7%           | 647    | 00:00:00     | SELECT current_setting($1)::numeric >= $2
 00:00:00.018523 | 6.0%           | 634    | 00:00:00     | SELECT extversion::text AS version FROM pg_catalog.pg_extension WHERE extname = $1
 00:00:00.024118 | 7.8%           | 634    | 00:00:00     | SELECT quote_ident(nspname::text) FROM pg_extension x INNER JOIN pg_namespace ns ON ns.oid = x.extnamespace WHERE x.extname = $1
 00:00:00.179293 | 57.7%          | 634    | 00:00:00     | SELECT pid, state                                                                                                               +
                 |                |        |              |                 FROM pg_stat_activity                                                                                           +
                 |                |        |              |                 WHERE state = $1                                                                                                +
                 |                |        |              |                 AND query like $2                                                                                               +
                 |                |        |              |                 AND NOT query like $3
 00:00:00.035144 | 11.3%          | 634    | 00:00:00     | SELECT CASE                                                                                                                     +
                 |                |        |              |                 WHEN $1 IN (SELECT extname FROM pg_extension) THEN $2                                                           +
                 |                |        |              |                 WHEN pg_is_in_recovery() THEN $3                                                                                +
                 |                |        |              |                 WHEN current_setting($4) LIKE $5 THEN $6                                                                        +
                 |                |        |              |                 ELSE $7                                                                                                         +
                 |                |        |              |                 END as status
 00:00:00.020609 | 6.6%           | 634    | 00:00:00     | SET statement_timeout = '10s'
 00:00:00.000411 | 0.1%           | 11     | 00:00:00     | SELECT exists(                                                                                                                  +
                 |                |        |              |   SELECT $1                                                                                                                     +
                 |                |        |              |   FROM pg_extension e                                                                                                           +
                 |                |        |              |     LEFT JOIN pg_namespace n ON n.oid = e.extnamespace                                                                          +
                 |                |        |              |   WHERE e.extname = $2 AND n.nspname IN ($3, $4)                                                                                +
                 |                |        |              | ) AS available
 00:00:00.000088 | 0.0%           | 11     | 00:00:00     | SHOW server_version
 00:00:00.000166 | 0.1%           | 6      | 00:00:00     | SELECT exists(                                                                                                                  +
                 |                |        |              |   SELECT $1 FROM pg_extension e LEFT JOIN pg_namespace n ON n.oid = e.extnamespace                                              +
                 |                |        |              |   WHERE e.extname=$2 AND n.nspname = $3                                                                                         +
                 |                |        |              | ) AS available
(10 rows)

```
- test on a PG16 Postgres:
```
heroku pg:calls HEROKU_POSTGRESQL_TCOLL_GRAY_URL -a tc-data-dev
 total_exec_time | prop_exec_time | ncalls |  sync_io_time   |                                                              query                                                               
-----------------+----------------+--------+-----------------+----------------------------------------------------------------------------------------------------------------------------------
 00:00:00.237361 | 0.1%           | 40,315 | 00:00:00        | SELECT $1
 00:00:00.39771  | 0.1%           | 20,670 | 00:00:00        | SELECT current_setting($1)::numeric >= $2
 00:00:00.396909 | 0.1%           | 20,668 | 00:00:00        | SET statement_timeout = '10s'
 00:00:00.849536 | 0.2%           | 20,668 | 00:00:00        | SELECT quote_ident(nspname::text) FROM pg_extension x INNER JOIN pg_namespace ns ON ns.oid = x.extnamespace WHERE x.extname = $1
 00:00:05.761641 | 1.2%           | 20,668 | 00:00:00.000027 | SELECT pid, state                                                                                                               +
                 |                |        |                 |                 FROM pg_stat_activity                                                                                           +
                 |                |        |                 |                 WHERE state = $1                                                                                                +
                 |                |        |                 |                 AND query like $2                                                                                               +
                 |                |        |                 |                 AND NOT query like $3
 00:00:00.674179 | 0.1%           | 20,668 | 00:00:00        | SELECT extversion::text AS version FROM pg_catalog.pg_extension WHERE extname = $1
 00:07:33.687342 | 97.9%          | 20,668 | 00:00:00        | SELECT queryid AS query_id, calls, total_time, blk_read_time, blk_write_time                                                    +
                 |                |        |                 |                 FROM (                                                                                                          +
                 |                |        |                 |                         SELECT queryid,                                                                                         +
                 |                |        |                 |                         SUM(calls) OVER (PARTITION BY queryid) AS calls,                                                        +
                 |                |        |                 |                         SUM(total_exec_time) OVER (PARTITION BY queryid) AS total_time,                                         +
                 |                |        |                 |                         SUM(blk_read_time) OVER (PARTITION BY queryid) AS blk_read_time,                                        +
                 |                |        |                 |                         SUM(blk_write_time) OVER (PARTITION BY queryid) AS blk_write_time,                                      +
                 |                |        |                 |                         (total_exec_time / SUM(total_exec_time) over ()) * $1 AS time_spent                                     +
                 |                |        |                 |                         FROM public.pg_stat_statements($2)                                                                      +
                 |                |        |                 |                         WHERE userid = (                                                                                        +
                 |                |        |                 |                                 SELECT usesysid                                                                                 +
                 |                |        |                 |                                 FROM pg_user                                                                                    +
                 |                |        |                 |                                 WHERE usename = current_user LIMIT $3                                                           +
                 |                |        |                 |                         )                                                                                                       +
                 |                |        |                 |                 ) ts                                                                                                            +
                 |                |        |                 |                 WHERE time_spent >= $4                                                                                          +
                 |                |        |                 |                 GROUP BY queryid, calls, total_time, blk_read_time, blk_write_time
 00:00:01.244454 | 0.3%           | 20,668 | 00:00:00        | SELECT CASE                                                                                                                     +
                 |                |        |                 |                 WHEN $1 IN (SELECT extname FROM pg_extension) THEN $2                                                           +
                 |                |        |                 |                 WHEN pg_is_in_recovery() THEN $3                                                                                +
                 |                |        |                 |                 WHEN current_setting($4) LIKE $5 THEN $6                                                                        +
                 |                |        |                 |                 ELSE $7                                                                                                         +
                 |                |        |                 |                 END as status
 00:00:00.000042 | 0.0%           | 5      | 00:00:00        | SET application_name='Heroku Postgres - Automation - 52.4.86.217:27879'
 00:00:00.000042 | 0.0%           | 5      | 00:00:00        | SET application_name='Heroku Postgres - Automation - 52.4.86.217:15716'
(10 rows)


```

ref: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000029ob80YAA/view