### PR TITLE
version set to 2.0.0 | W-18005546

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heroku-cli/heroku-pg-extras",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heroku-cli/heroku-pg-extras",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@heroku-cli/command": "^11.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/heroku-pg-extras",
   "description": "Heroku PG Extras CLI plugin",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": "Heroku",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg-extras/issues"


### PR DESCRIPTION
## Description

Version bump for heroku-pg-extras to v2.0.0

## Testing

Version bump to package.json.
Previously tested changes in pre-release and main release. 

## Screenshots (if applicable)

## SOC2 Compliance

Gus Work Item: [W-18005546](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Asy3vYAB/view) (Heroku internal)
