### PR TITLE
feat: Exclude superuser, ongoing, physical backup queries from results

### DIFF
--- a/src/commands/pg/long-running-queries.ts
+++ b/src/commands/pg/long-running-queries.ts
@@ -15,6 +15,11 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND NOT (
+    state = 'idle in transaction'
+    AND usename = 'postgres'
+    AND query LIKE '%pg_backup_start%'
+  )
 ORDER BY
   now() - pg_stat_activity.query_start DESC;
 `.trim()

--- a/test/commands/pg/long-running-queries.test.ts
+++ b/test/commands/pg/long-running-queries.test.ts
@@ -50,6 +50,11 @@ WHERE
   pg_stat_activity.query <> ''::text
   AND state <> 'idle'
   AND now() - pg_stat_activity.query_start > interval '5 minutes'
+  AND NOT (
+    state = 'idle in transaction'
+    AND usename = 'postgres'
+    AND query LIKE '%pg_backup_start%'
+  )
 ORDER BY
   now() - pg_stat_activity.query_start DESC;`
 
@@ -87,6 +92,16 @@ ORDER BY
       // Should order by duration descending
       expect(query).to.contain('ORDER BY')
       expect(query).to.contain('now() - pg_stat_activity.query_start DESC')
+    })
+
+    it('should exclude wal-e backup queries', function () {
+      const query = generateLongRunningQueriesQuery()
+
+      // Should exclude wal-e backup queries (idle in transaction + postgres user + pg_backup_start)
+      // Normalize whitespace to check that all three conditions are together in an AND NOT block
+      const normalizedQuery = query.replaceAll(/\s+/g, ' ')
+      const expectedPattern = "AND NOT ( state = 'idle in transaction' AND usename = 'postgres' AND query LIKE '%pg_backup_start%' )"
+      expect(normalizedQuery).to.contain(expectedPattern)
     })
   })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Heroku Postgres runs physical backups as part of continuous protection. These can take some time and the underlying `pg_start_backup` (on PG15+) queries will appear as long running, idle in transaction processes.

These are unnecessary noise and can confuse users over processes they have no control over. The backup process queries will of course be still visible through `pg_stat_activity`, but we should remove it from our troubleshooting commands to reduce confusion - it is expected for these long transactions to exist on the database during base backups.

See: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-BACKUP and https://www.postgresql.org/docs/current/continuous-archiving.html.


Related: https://github.com/heroku/cli/pull/3675
## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **perf**: Performance improvement
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **docs**: Documentation change
- [ ] **style**: Styling update
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **tests**: Add/update/remove tests
- [ ] **build**: Change to the build system
- [ ] **ci**: Continuous integration workflow update

## Testing
**Notes**: 
<!-- Add any context/setup necessary for testing. -->

This is a minor change and its impact is only visible, in normal conditions, when running the command against a database with a long running command. It is therefore not immediately testable by non-data operators that can't start a backup on the database that this change aims to exclude from the results.

**Steps**:
1. Passing CI suffices, overall

but:
1. On a database with a long-running base backup, run `pg:long-running-queries`. The result should _not_ include the internal superuser (postgres) connection waiting idle in transaction for pg_backup_start.

## Screenshots (if applicable)

On the `main` branch:

```
➜  ~ heroku  pg:long-running-queries DATABASE -a xxx
   pid   |        duration         |                                                                               query
---------+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  295818 | 13 days 14:53:57.339817 | START_REPLICATION 1F4C23/E000000 TIMELINE 11
  327427 | 13 days 13:30:59.655459 | START_REPLICATION 1F4C43/1D000000 TIMELINE 11
 2818310 | 06:24:47.381329         | SELECT file_name,   lpad(file_offset::text, 8, '0') AS file_offset FROM pg_walfile_name_offset(  pg_backup_start('freeze_start_2026-04-17T05:18:28.142280+00:00'))
 2925587 | 01:09:23.073419         | autovacuum: VACUUM pg_toast.pg_toast_938774242
..
```


Switching over to this branch, we confirm the command works and the process doesn't show up anymore:

```
➜  ~ heroku  pg:long-running-queries DATABASE -a xxx
   pid   |        duration         |                                                         query
---------+-------------------------+-----------------------------------------------------------------------------------------------------------------------
  295818 | 13 days 14:57:21.682592 | START_REPLICATION 1F4C23/E000000 TIMELINE 11
  327427 | 13 days 13:34:23.998234 | START_REPLICATION 1F4C43/1D000000 TIMELINE 11
 2925587 | 01:12:47.416194         | autovacuum: VACUUM pg_toast.pg_toast_938774242
...
```

Back to main, for double-checking:

```
➜  ~ heroku  pg:long-running-queries DATABASE -a xxx
   pid   |        duration         |                                                                               query
---------+-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  295818 | 13 days 14:58:15.575446 | START_REPLICATION 1F4C23/E000000 TIMELINE 11
  327427 | 13 days 13:35:17.891088 | START_REPLICATION 1F4C43/1D000000 TIMELINE 11
 2818310 | 06:29:05.616958         | SELECT file_name,   lpad(file_offset::text, 8, '0') AS file_offset FROM pg_walfile_name_offset(  pg_backup_start('freeze_start_2026-04-17T05:18:28.142280+00:00'))
 2925587 | 01:13:41.309048         | autovacuum: VACUUM pg_toast.pg_toast_938774242

```


## Related Issues
GUS work item: [W-22101694](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YM48QYAT/view)
