### PR TITLE
chore(dependabot): canonical grouping, weekly+monday, 1d cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,29 +5,52 @@ updates:
   open-pull-requests-limit: 5
   schedule:
       interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      day: "monday"
+  cooldown:
+      default-days: 1
   commit-message:
       prefix: "deps"
+  groups:
+      version-updates:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      security-updates:
+        applies-to: security-updates
+        update-types:
+          - "minor"
+          - "patch"
 - package-ecosystem: "npm"
   directory: "/"
   open-pull-requests-limit: 5
   schedule:
       interval: "weekly"
-      time: "12:00"
-      day: "sunday"
-      timezone: "America/Los_Angeles"
+      day: "monday"
+  cooldown:
+      default-days: 1
   commit-message:
       prefix: "fix"
       prefix-development: "chore"
       include: "scope"
   groups:
-      dev-patch-minor-dependencies:
+      development-version-updates:
+        applies-to: version-updates
         dependency-type: "development"
         update-types:
-          - "patch"
           - "minor"
+          - "patch"
+      production-version-updates:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      security-updates:
+        applies-to: "security-updates"
+        update-types:
+          - "minor"
+          - "patch"
   ignore:
     - dependency-name: "@oclif/core"
       update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Apply the team's canonical Dependabot config: weekly schedule pinned to Monday, 1-day cooldown to mitigate supply-chain surprises, and grouping that batches minor/patch updates while leaving major-version bumps and security advisories ungrouped.

For ecosystems with a dev/prod distinction (bundler, npm), version-updates split into `development-version-updates` and `production-version-updates` groups. For others (gomod, terraform, github-actions), a single `version-updates` group applies. A `security-updates` group batches grouped security minor/patch fixes; advisories outside that group still open individually as soon as Dependabot detects them.

## Relevant links

- Work item: [W-22510154](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002a6aoKYAQ/view)
- Discussion: https://salesforce-internal.slack.com/archives/CC4ESHZKP/p1778853621013509

## Test plan

- [ ] N/A — Dependabot config only. Effect will be visible at the next scheduled run (Monday).