### PR TITLE
feat!: deprecate this plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # `pg-extras` CLI Plugin
 
+> [!IMPORTANT]
+> This repo is archived. Refer to the Heroku CLI for updates to these commands.
+
 A Heroku CLI plugin providing shortcuts to common Postgres introspection queries.
 
 This plugin is used to obtain information about a Heroku Postgres instance,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
+        "@heroku-cli/color": "^2.0.4",
         "@heroku-cli/command": "^11.5.0",
         "@heroku-cli/schema": "^2.0.0",
         "@heroku/heroku-cli-util": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/heroku/heroku-pg-extras/issues"
   },
   "dependencies": {
+    "@heroku-cli/color": "^2.0.4",
     "@heroku-cli/command": "^11.5.0",
     "@heroku-cli/schema": "^2.0.0",
     "@heroku/heroku-cli-util": "9.1.3",

--- a/src/commands/pg/bloat.ts
+++ b/src/commands/pg/bloat.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateBloatQuery = (): string => `
 WITH constants AS (
       SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
@@ -79,6 +81,7 @@ export default class PgBloat extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgBloat)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/blocking.ts
+++ b/src/commands/pg/blocking.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateBlockingQuery = (): string => `
 SELECT bl.pid AS blocked_pid,
   ka.query AS blocking_statement,
@@ -33,6 +35,7 @@ export default class PgBlocking extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgBlocking)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/cache-hit.ts
+++ b/src/commands/pg/cache-hit.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateCacheHitQuery = (): string => `
 SELECT
   'index hit rate' AS name,
@@ -30,6 +32,7 @@ export default class PgCacheHit extends Command {
   static hiddenAliases = ['pg:cache_hit']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgCacheHit)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/calls.ts
+++ b/src/commands/pg/calls.ts
@@ -45,6 +45,7 @@ export default class PgCalls extends Command {
   }
 
   public async run(): Promise<void> {
+    util.warnDeprecated()
     const {args, flags} = await this.parse(PgCalls)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/extensions.ts
+++ b/src/commands/pg/extensions.ts
@@ -28,6 +28,7 @@ export default class PgExtensions extends Command {
   }
 
   public async run(): Promise<void> {
+    util.warnDeprecated()
     const {args, flags} = await this.parse(PgExtensions)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/fdwsql.ts
+++ b/src/commands/pg/fdwsql.ts
@@ -47,6 +47,7 @@ export default class PgFdwsql extends Command {
   }
 
   public async run(): Promise<void> {
+    util.warnDeprecated()
     const {args, flags} = await this.parse(PgFdwsql)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/index-size.ts
+++ b/src/commands/pg/index-size.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateIndexSizeQuery = (): string => `
 SELECT c.relname AS name,
   pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
@@ -30,6 +32,7 @@ export default class PgIndexSize extends Command {
   static hiddenAliases = ['pg:index_size']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgIndexSize)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/index-usage.ts
+++ b/src/commands/pg/index-usage.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateIndexUsageQuery = (): string => `
 SELECT relname,
    CASE idx_scan
@@ -31,6 +33,7 @@ export default class PgIndexUsage extends Command {
   static hiddenAliases = ['pg:index_usage']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgIndexUsage)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/locks.ts
+++ b/src/commands/pg/locks.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateLocksQuery = (truncate: boolean): string => {
   const querySnippet = truncate
     ? 'CASE WHEN length(pg_stat_activity.query) <= 40 THEN pg_stat_activity.query ELSE substr(pg_stat_activity.query, 0, 39) || \'...\' END'
@@ -40,6 +42,7 @@ export default class PgLocks extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgLocks)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/long-running-queries.ts
+++ b/src/commands/pg/long-running-queries.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateLongRunningQueriesQuery = (): string => `
 SELECT
   pid,
@@ -33,6 +35,7 @@ export default class PgLongRunningQueries extends Command {
   static hiddenAliases = ['pg:long_running_queries']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgLongRunningQueries)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/mandelbrot.ts
+++ b/src/commands/pg/mandelbrot.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateMandelbrotQuery = (): string => `
   WITH RECURSIVE Z(IX, IY, CX, CY, X, Y, I) AS (
             SELECT IX, IY, X::float, Y::float, X::float, Y::float, 0
@@ -38,6 +40,7 @@ export default class PgMandelbrot extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgMandelbrot)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dbConnection = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/outliers.ts
+++ b/src/commands/pg/outliers.ts
@@ -4,7 +4,9 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
-import {ensurePGStatStatement, newBlkTimeFields, newTotalExecTimeField} from '../../lib/util'
+import {
+  ensurePGStatStatement, newBlkTimeFields, newTotalExecTimeField, warnDeprecated,
+} from '../../lib/util'
 
 export const generateOutliersQuery = async (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -57,6 +59,7 @@ export default class PgOutliers extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgOutliers)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/records-rank.ts
+++ b/src/commands/pg/records-rank.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateRecordsRankQuery = (): string => `
 SELECT
   relname AS name,
@@ -28,6 +30,7 @@ export default class PgRecordsRank extends Command {
   static hiddenAliases = ['pg:records_rank']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgRecordsRank)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/seq-scans.ts
+++ b/src/commands/pg/seq-scans.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateSeqScansQuery = (): string => `
 SELECT relname AS name,
        seq_scan as count
@@ -26,6 +28,7 @@ export default class PgSeqScans extends Command {
   static hiddenAliases = ['pg:seq_scans']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgSeqScans)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/stats-reset.ts
+++ b/src/commands/pg/stats-reset.ts
@@ -4,7 +4,7 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
-import {ensureEssentialTierPlan} from '../../lib/util'
+import {ensureEssentialTierPlan, warnDeprecated} from '../../lib/util'
 
 export default class PgStatsReset extends Command {
   static args = {
@@ -20,6 +20,7 @@ export default class PgStatsReset extends Command {
   static hiddenAliases = ['pg:stats_reset']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgStatsReset)
     const {app} = flags
     const {database} = args

--- a/src/commands/pg/table-indexes-size.ts
+++ b/src/commands/pg/table-indexes-size.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateTableIndexesSizeQuery = (): string => `
 SELECT c.relname AS table,
   pg_size_pretty(pg_indexes_size(c.oid)) AS index_size
@@ -29,6 +31,7 @@ export default class PgTableIndexesSize extends Command {
   static hiddenAliases = ['pg:table_indexes_size']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgTableIndexesSize)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/table-size.ts
+++ b/src/commands/pg/table-size.ts
@@ -6,6 +6,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateTableSizeQuery = (): string => `SELECT c.relname AS name,
   pg_size_pretty(pg_table_size(c.oid)) AS size
 FROM pg_class c
@@ -28,6 +30,7 @@ export default class PgTableSize extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgTableSize)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: ConnectionDetailsWithAttachment = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/total-index-size.ts
+++ b/src/commands/pg/total-index-size.ts
@@ -4,6 +4,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateTotalIndexSizeQuery = (): string => `
 SELECT pg_size_pretty(sum(c.relpages::bigint*8192)::bigint) AS size
 FROM pg_class c
@@ -27,6 +29,7 @@ export default class PgTotalIndexSize extends Command {
   static hiddenAliases = ['pg:total_index_size']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgTotalIndexSize)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/total-table-size.ts
+++ b/src/commands/pg/total-table-size.ts
@@ -6,6 +6,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateTotalTableSizeQuery = (): string => `SELECT c.relname AS name,
   pg_size_pretty(pg_total_relation_size(c.oid)) AS size
 FROM pg_class c
@@ -28,6 +30,7 @@ export default class PgTotalTableSize extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgTotalTableSize)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: ConnectionDetailsWithAttachment = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/unused-indexes.ts
+++ b/src/commands/pg/unused-indexes.ts
@@ -6,6 +6,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateUnusedIndexesQuery = (): string => `SELECT
   schemaname || '.' || relname AS table,
   indexrelname AS index,
@@ -30,6 +32,7 @@ export default class PgUnusedIndexes extends Command {
   }
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgUnusedIndexes)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: ConnectionDetailsWithAttachment = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/user-connections.ts
+++ b/src/commands/pg/user-connections.ts
@@ -6,6 +6,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateUserConnectionsQuery = (): string => `SELECT 
   usename AS credential,
   count(*) AS connections
@@ -28,6 +30,7 @@ export default class PgUserConnections extends Command {
   static hiddenAliases = ['pg:user_connections']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgUserConnections)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: ConnectionDetailsWithAttachment = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/commands/pg/vacuum-stats.ts
+++ b/src/commands/pg/vacuum-stats.ts
@@ -6,6 +6,8 @@ import {utils} from '@heroku/heroku-cli-util'
 import {Command, flags} from '@heroku-cli/command'
 import {Args, ux} from '@oclif/core'
 
+import {warnDeprecated} from '../../lib/util'
+
 export const generateVacuumStatsQuery = (): string => `WITH table_opts AS (
   SELECT
     pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
@@ -59,6 +61,7 @@ export default class PgVacuumStats extends Command {
   static hiddenAliases = ['pg:vacuum_stats']
 
   public async run(): Promise<void> {
+    warnDeprecated()
     const {args, flags} = await this.parse(PgVacuumStats)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: ConnectionDetailsWithAttachment = await utils.pg.fetcher.database(this.heroku as any, flags.app, args.database)

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -2,12 +2,17 @@
 
 import type {ConnectionDetailsWithAttachment} from '@heroku/heroku-cli-util'
 
+import {color} from '@heroku-cli/color'
 import {utils} from '@heroku/heroku-cli-util'
 import * as Heroku from '@heroku-cli/schema'
 import {ux} from '@oclif/core'
 
 interface Plan {
   plan: Heroku.AddOn['plan']
+}
+
+export function warnDeprecated(): void {
+  ux.warn(`This command is now available as part of the Heroku CLI. Uninstall this archived plugin by running ${color.cmd('heroku plugins:uninstall @heroku-cli/heroku-pg-extras')}.`)
 }
 
 export async function ensurePGStatStatement(db: ConnectionDetailsWithAttachment): Promise<void> {

--- a/test/commands/pg/bloat.test.ts
+++ b/test/commands/pg/bloat.test.ts
@@ -124,7 +124,7 @@ index   | public     | users::idx  | 1.8   | 512 kB
         table   | public     | users       | 2.5   | 1.2 MB
         index   | public     | users::idx  | 1.8   | 512 kB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/blocking.test.ts
+++ b/test/commands/pg/blocking.test.ts
@@ -77,7 +77,7 @@ WHERE NOT bl.granted`
         -------------|-------------------|-------------------|--------------|-------------------|------------------
         123          | SELECT * FROM t1  | 00:01:30         | 456          | UPDATE t2 SET...  | 00:00:45
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/cache-hit.test.ts
+++ b/test/commands/pg/cache-hit.test.ts
@@ -5,6 +5,7 @@ import heredoc from 'tsheredoc'
 
 import PgCacheHit, {generateCacheHitQuery} from '../../../src/commands/pg/cache-hit'
 import {setupSimpleCommandMocks, testDatabaseConnectionFailure, testSQLExecutionFailure} from '../../helpers/mock-utils'
+import stripAnsi from '../../helpers/strip-ansi'
 import {runCommand} from '../../run-command'
 
 describe('pg:cache-hit', function () {
@@ -74,7 +75,11 @@ FROM pg_statio_user_tables;`
         index hit rate  | 0.95
         table hit rate  | 0.87
       `)
-      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
+      // ux.warn wraps the message across lines, so normalize whitespace before
+      // asserting the full deprecation notice (including the uninstall command).
+      const normalizedStderr = stripAnsi(stderr.output).replaceAll(/\s+/g, ' ')
+      expect(normalizedStderr).to.contain('This command is now available as part of the Heroku CLI.')
+      expect(normalizedStderr).to.contain('Uninstall this archived plugin by running heroku plugins:uninstall @heroku-cli/heroku-pg-extras')
     })
   })
 

--- a/test/commands/pg/cache-hit.test.ts
+++ b/test/commands/pg/cache-hit.test.ts
@@ -74,7 +74,7 @@ FROM pg_statio_user_tables;`
         index hit rate  | 0.95
         table hit rate  | 0.87
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/calls.test.ts
+++ b/test/commands/pg/calls.test.ts
@@ -150,7 +150,7 @@ LIMIT 10`
         SELECT * FROM users | 1.23 | 0.15 | 100 | 0.05
         UPDATE users SET... | 2.45 | 0.30 | 50 | 0.12
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('handles truncate flag correctly', async function () {
@@ -167,7 +167,7 @@ LIMIT 10`
         SELECT * FROM users | 1.23 | 0.15 | 100 | 0.05
         UPDATE users SET... | 2.45 | 0.30 | 50 | 0.12
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/extensions.test.ts
+++ b/test/commands/pg/extensions.test.ts
@@ -89,7 +89,7 @@ uuid-ossp | 1.1 | public | generate universally unique identifiers
         plpgsql | 1.0 | pg_catalog | PL/pgSQL procedural language
         uuid-ossp | 1.1 | public | generate universally unique identifiers
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/fdwsql.test.ts
+++ b/test/commands/pg/fdwsql.test.ts
@@ -93,7 +93,7 @@ ORDER BY c.relname;`
       expect(stdout.output).to.include('CREATE SERVER test_prefix_db')
       expect(stdout.output).to.include('CREATE USER MAPPING FOR CURRENT_USER')
       expect(stdout.output).to.include('CREATE FOREIGN TABLE test_prefix_table1')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('handles empty foreign table results gracefully', async function () {
@@ -107,14 +107,14 @@ ORDER BY c.relname;`
       expect(stdout.output).to.include('DROP SERVER IF EXISTS test_prefix_db;')
       expect(stdout.output).to.include('CREATE SERVER test_prefix_db')
       expect(stdout.output).to.include('CREATE USER MAPPING FOR CURRENT_USER')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       await runCommand(PgFdwsql, ['--app', 'my-app', 'test_prefix', 'custom-db'])
 
       expect(stdout.output).to.include('CREATE EXTENSION IF NOT EXISTS postgres_fdw;')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/index-size.test.ts
+++ b/test/commands/pg/index-size.test.ts
@@ -91,7 +91,7 @@ ORDER BY sum(c.relpages) DESC;`
         idx_posts_title | 1.8 MB
         idx_comments_user_id | 1.2 MB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/index-usage.test.ts
+++ b/test/commands/pg/index-usage.test.ts
@@ -86,7 +86,7 @@ comments | 92                          | 25000
         posts    | 87                          | 5000
         comments | 92                          | 25000
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/locks.test.ts
+++ b/test/commands/pg/locks.test.ts
@@ -116,7 +116,7 @@ pid | relname | transactionid | granted | query_snippet | age
         123 | users   | 456789        | t       | UPDATE users  | 00:01:30
         789 | posts   | 123456        | f       | DELETE FROM   | 00:00:45
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('handles truncate flag correctly', async function () {
@@ -128,7 +128,7 @@ pid | relname | transactionid | granted | query_snippet | age
         123 | users   | 456789        | t       | UPDATE users  | 00:01:30
         789 | posts   | 123456        | f       | DELETE FROM   | 00:00:45
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/long-running-queries.test.ts
+++ b/test/commands/pg/long-running-queries.test.ts
@@ -101,7 +101,7 @@ ORDER BY
         456 | 00:08:15 | UPDATE users SET status = 'processing' WHERE id > 1000
         789 | 00:06:45 | DELETE FROM logs WHERE created_at < '2023-01-01'
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/mandelbrot.test.ts
+++ b/test/commands/pg/mandelbrot.test.ts
@@ -115,7 +115,7 @@ ORDER BY IY`.trim()
           .,,,-----++++%%%%@@@@####
           .,,,-----++++%%%%@@@@####
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/outliers.test.ts
+++ b/test/commands/pg/outliers.test.ts
@@ -181,7 +181,7 @@ LIMIT 10`
         00:00:45.789   | 15.2%          | 567    | 00:00:08.123 | UPDATE users SET status = 'processing' WHERE id > 1000
         00:00:30.456   | 10.1%          | 890    | 00:00:05.789 | DELETE FROM logs WHERE created_at < '2023-01-01'
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('handles truncate flag correctly', async function () {
@@ -192,7 +192,7 @@ LIMIT 10`
 
       await runCommand(PgOutliers, ['--app', 'my-app', '--truncate'])
       expect(stdout.output).to.include('total_exec_time')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('handles custom limit correctly', async function () {
@@ -203,14 +203,14 @@ LIMIT 10`
 
       await runCommand(PgOutliers, ['--app', 'my-app', '--num', '5'])
       expect(stdout.output).to.include('total_exec_time')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('resets statistics when reset flag is specified', async function () {
       await runCommand(PgOutliers, ['--app', 'my-app', '--reset'])
       // The reset command executes pg_stat_statements_reset() but doesn't log output
       expect(stdout.output).to.eq('')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/records-rank.test.ts
+++ b/test/commands/pg/records-rank.test.ts
@@ -79,7 +79,7 @@ ORDER BY
         posts | 5000
         comments | 25000
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/seq-scans.test.ts
+++ b/test/commands/pg/seq-scans.test.ts
@@ -77,7 +77,7 @@ ORDER BY seq_scan DESC;`
         posts | 75
         comments | 25
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/stats-reset.test.ts
+++ b/test/commands/pg/stats-reset.test.ts
@@ -60,7 +60,7 @@ describe('pg:stats-reset', function () {
           await runCommand(PgStatsResetMocked, ['--app=my-app'])
 
           expect(stripAnsi(stdout.output)).to.include('Statistics reset successfully')
-          expect(stderr.output).to.equal('')
+          expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
         } finally {
           // Cleanup is handled by sandbox.restore()
         }
@@ -157,7 +157,7 @@ describe('pg:stats-reset', function () {
           await runCommand(PgStatsResetMocked, ['--app=my-app', 'custom-db'])
 
           expect(stripAnsi(stdout.output)).to.include('Custom database statistics reset successfully')
-          expect(stderr.output).to.equal('')
+          expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
         } finally {
           // Cleanup is handled by sandbox.restore()
         }

--- a/test/commands/pg/table-indexes-size.test.ts
+++ b/test/commands/pg/table-indexes-size.test.ts
@@ -91,7 +91,7 @@ ORDER BY pg_indexes_size(c.oid) DESC;`
         posts | 1.8 MB
         comments | 1.2 MB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/table-size.test.ts
+++ b/test/commands/pg/table-size.test.ts
@@ -87,21 +87,21 @@ ORDER BY pg_table_size(c.oid) DESC;`
         posts | 25 MB
         comments | 10 MB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('shows empty result when no tables are found', async function () {
       execStub.resolves('')
       await runCommand(PgTableSize, ['--app', 'my-app'])
       expect(stdout.output).to.eq('\n')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       execStub.resolves('custom_table | 100 MB')
       await runCommand(PgTableSize, ['--app', 'my-app', 'custom-db'])
       expect(stdout.output).to.contain('custom_table | 100 MB')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/total-index-size.test.ts
+++ b/test/commands/pg/total-index-size.test.ts
@@ -79,7 +79,7 @@ AND c.relkind='i';`
         -----
         15.2 MB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/total-table-size.test.ts
+++ b/test/commands/pg/total-table-size.test.ts
@@ -87,21 +87,21 @@ ORDER BY pg_total_relation_size(c.oid) DESC;`
         posts | 40 MB
         comments | 15 MB
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('shows empty result when no tables are found', async function () {
       execStub.resolves('')
       await runCommand(PgTotalTableSize, ['--app', 'my-app'])
       expect(stdout.output).to.eq('\n')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       execStub.resolves('custom_table | 150 MB')
       await runCommand(PgTotalTableSize, ['--app', 'my-app', 'custom-db'])
       expect(stdout.output).to.contain('custom_table | 150 MB')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/unused-indexes.test.ts
+++ b/test/commands/pg/unused-indexes.test.ts
@@ -86,21 +86,21 @@ pg_relation_size(i.indexrelid) DESC;`
         public.users | idx_users_email | 2.1 MB | 12
         public.posts | idx_posts_created | 1.5 MB | 8
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('shows empty result when no unused indexes are found', async function () {
       execStub.resolves('')
       await runCommand(PgUnusedIndexes, ['--app', 'my-app'])
       expect(stdout.output).to.eq('\n')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       execStub.resolves('custom_table | custom_index | 3.0 MB | 5')
       await runCommand(PgUnusedIndexes, ['--app', 'my-app', 'custom-db'])
       expect(stdout.output).to.contain('custom_table | custom_index | 3.0 MB | 5')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/user-connections.test.ts
+++ b/test/commands/pg/user-connections.test.ts
@@ -83,21 +83,21 @@ ORDER BY connections DESC;`
         postgres   | 5
         app_user   | 3
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('shows empty result when no user connections are found', async function () {
       execStub.resolves('')
       await runCommand(PgUserConnections, ['--app', 'my-app'])
       expect(stdout.output).to.eq('\n')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       execStub.resolves('custom_user | 2')
       await runCommand(PgUserConnections, ['--app', 'my-app', 'custom-db'])
       expect(stdout.output).to.contain('custom_user | 2')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/commands/pg/vacuum-stats.test.ts
+++ b/test/commands/pg/vacuum-stats.test.ts
@@ -116,21 +116,21 @@ ORDER BY 1`
         public | users | 2024-01-15 10:30 | 2024-01-16 14:20 | 1,000 | 50 | 1,100 | yes
         public | posts | 2024-01-14 09:15 | 2024-01-15 16:45 | 5,000 | 200 | 5,500 |
       `)
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('shows empty result when no vacuum stats are found', async function () {
       execStub.resolves('')
       await runCommand(PgVacuumStats, ['--app', 'my-app'])
       expect(stdout.output).to.eq('\n')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
 
     it('executes query against specified database', async function () {
       execStub.resolves('custom_table | 2024-01-17 12:00 | 2024-01-17 12:00 | 100 | 5 | 110 | ')
       await runCommand(PgVacuumStats, ['--app', 'my-app', 'custom-db'])
       expect(stdout.output).to.contain('custom_table | 2024-01-17 12:00 | 2024-01-17 12:00 | 100 | 5 | 110 | ')
-      expect(stderr.output).to.eq('')
+      expect(stderr.output).to.contain('This command is now available as part of the Heroku CLI.')
     })
   })
 

--- a/test/lib/util.test.ts
+++ b/test/lib/util.test.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai'
 import sinon, {SinonSandbox, SinonStub} from 'sinon'
 
 import * as util from '../../src/lib/util'
+import stripAnsi from '../helpers/strip-ansi'
 import {setupSimpleCommandMocks} from '../helpers/mock-utils'
 
 describe('util - boolean functions', function () {
@@ -194,6 +195,19 @@ describe('util - boolean functions', function () {
 
       expect(uxErrorStub.calledOnce).to.be.true
       expect(uxErrorStub.firstCall.args[1]).to.deep.equal({exit: 1})
+    })
+  })
+
+  describe('warnDeprecated', function () {
+    it('warns that the command is now part of the Heroku CLI with uninstall instructions', function () {
+      const uxWarnStub = sandbox.stub(ux, 'warn')
+
+      util.warnDeprecated()
+
+      expect(uxWarnStub.calledOnce).to.be.true
+      const message = stripAnsi(uxWarnStub.firstCall.args[0] as string)
+      expect(message).to.include('This command is now available as part of the Heroku CLI.')
+      expect(message).to.include('heroku plugins:uninstall @heroku-cli/heroku-pg-extras')
     })
   })
 


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary

Now that these commands have been migrated to the CLI, we are deprecating this plugin.

- Added an archive notice to the top of the README.
- Created warnDeprecated() that warns users to uninstall the plugin.
- - warnDeprecated() called in all 22 pg commands.

Screenshot of what it looks like:

<img width="1923" height="290" alt="Screenshot 2026-07-06 at 1 04 17 PM" src="https://github.com/user-attachments/assets/73cb084d-6791-4be2-adaf-e21fcf4afd35" />

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **perf**: Performance improvement
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [x] **docs**: Documentation change
- [ ] **style**: Styling update
- [ ] **chore**: Change that does not affect production code
- [x] **refactor**: Refactoring existing code without changing behavior
- [x] **tests**: Add/update/remove tests
- [ ] **build**: Change to the build system
- [ ] **ci**: Continuous integration workflow update

## Testing

You can test that the warning happens by doing the following:

npm install ; npm run build

# 1. Simplest check — warning appears, then the "missing --app" error
./bin/run pg:cache-hit

# 2. Command with a required positional arg — warning still comes first
./bin/run pg:fdwsql

# 3. Prove the warning is on STDERR, not STDOUT (stdout is empty)
./bin/run pg:bloat 2>/dev/null        # → prints nothing
./bin/run pg:bloat 1>/dev/null        # → prints only the warning

## Screenshots (if applicable)

## Related Issues
GUS work item: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002YeozuYAB/view
